### PR TITLE
Improve basic functionality in commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 Todo before launching:
 
-- [ ] `exit` command
+- [X] `exit` command
 - [ ] Better paging (can we get input midway through a command?)
 - [ ] Tab completion

--- a/main.go
+++ b/main.go
@@ -148,7 +148,7 @@ These shell commands are defined internally. Type `+"`help`"+` to see this list.
 
  ls		list contents of current directory
  cat [file]	display contents of current file
- 
+ exit	exits the terminal
 psst! try running 'ls' to get started`)
 							},
 							"ls": func(args []string) {
@@ -267,6 +267,10 @@ psst! try running 'ls' to get started`)
 
 								fmt.Fprint(term, "\r"+strings.Join(contentLines[linesToShow:], "\n"))
 								fmt.Fprint(term, "\n\n(easier to read this file online? "+file[1]+")")
+							},
+							"exit" : func(args[] string) {
+								fmt.Fprintln(term, "meow! see yoou later!")
+								channel.Close()
 							},
 						}
 

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 	"time"
+	"text/tabwriter"
 
 	"github.com/charmbracelet/glamour"
 	"golang.org/x/crypto/ssh"
@@ -142,14 +143,23 @@ func main() {
 
 						cmds := map[string]func([]string){
 							"help": func(args []string) {
-								fmt.Fprintln(term, `HACK CLUB JOBS TERMINAL, version 1.0.0-release (x86_64).
+								fmt.Fprintln(term, "HACK CLUB JOBS TERMINAL, version 1.0.0-release (x86_64).")
 
-These shell commands are defined internally. Type `+"`help`"+` to see this list.
+								fmt.Fprintln(term,"These shell commands are defined internally. Type `+\"`help`\"+` to see this list.")
+								// use tabwriter to neatly format command help
+								helpWriter := tabwriter.NewWriter(term, 8, 8,0,'\t',0)
+								commands := [][]string{
+									[]string{"ls","list contents of current directory"},
+									[]string{"cat [file]","display contents of current file"},
+									[]string{"exit","exits the terminal"},
+								}
+								for _, command := range commands {
+									fmt.Fprintf(helpWriter,"%s\t%s\r\n", command[0], command[1])
+								}
+								helpWriter.Flush()
+								fmt.Fprintln(term,"psst! try running 'ls' to get started")
 
- ls		list contents of current directory
- cat [file]	display contents of current file
- exit	exits the terminal
-psst! try running 'ls' to get started`)
+
 							},
 							"ls": func(args []string) {
 								fileNames := make([]string, len(files))


### PR DESCRIPTION
I added an exit command, which currently functions on a simple basis by closing the current connection prematurely, which is the solution utilized by more powerful ssh systems (along with cleanup, etc. that is not currently necessary). I also rewrote the logic for the help function by utilizing a slice to store the commands in an extensible way, and the `stdlib` feature `text/tabwriter`, which smartly organizes text into rows and columns, to format the help messages.