### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,3 @@ vendor/
 
 # Directory for private key
 tmp/
-
-# IDE-specific directories
-.vscode/
-.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,23 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+vendor/
+
+
+# Directory for private key
 tmp/
+
+# IDE-specific directories
+.vscode/
+.idea/


### PR DESCRIPTION
Update .gitignore to include vendored directories, other default github recommendations, and IDE-specific directories, e.g. .vscode